### PR TITLE
✨Add generate_unique_name function for dynamic credential naming

### DIFF
--- a/src/sourcerer/infrastructure/utils.py
+++ b/src/sourcerer/infrastructure/utils.py
@@ -6,6 +6,7 @@ including UUID generation, MIME type detection, and file type checking.
 """
 
 import mimetypes
+import random
 import uuid
 from pathlib import Path
 
@@ -102,3 +103,117 @@ class Singleton(type):
         if cls not in cls._instances:
             cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
+
+
+def generate_unique_name() -> str:
+    """
+    Generate a unique name for a file or directory.
+
+    Returns:
+        str: A unique name
+    """
+    adjectives = [
+        "goofy",
+        "quirky",
+        "snappy",
+        "witty",
+        "bubbly",
+        "zany",
+        "wonky",
+        "clumsy",
+        "cheeky",
+        "sassy",
+        "cryptic",
+        "shadowy",
+        "enigmatic",
+        "arcane",
+        "veiled",
+        "hidden",
+        "phantasmal",
+        "whispering",
+        "hollow",
+        "ghostly",
+        "mighty",
+        "fierce",
+        "brave",
+        "bold",
+        "ironclad",
+        "unyielding",
+        "stormforged",
+        "grim",
+        "feral",
+        "dauntless",
+        "stellar",
+        "vivid",
+        "luminous",
+        "glimmering",
+        "blazing",
+        "radiant",
+        "shimmering",
+        "snazzy",
+        "flashy",
+        "dazzling",
+    ]
+
+    names = [
+        "gandalf",
+        "merlin",
+        "morgana",
+        "radagast",
+        "saruman",
+        "galadriel",
+        "smaug",
+        "elminster",
+        "ambrosius",
+        "balrog",
+        "sauron",
+        "rivendell",
+        "azkaban",
+        "gryffindor",
+        "slytherin",
+        "rowena",
+        "helga",
+        "alatar",
+        "pellinore",
+        "nimue",
+        "glorfindel",
+        "melian",
+        "feanor",
+        "titania",
+        "oberon",
+        "cerberus",
+        "phoenix",
+        "gryphon",
+        "hydra",
+        "basilisk",
+        "leviathan",
+        "wraith",
+        "djinn",
+        "fae",
+        "nymph",
+        "dryad",
+        "selkie",
+        "witchking",
+        "morwen",
+        "telvanni",
+        "daedric",
+        "argonian",
+        "auriel",
+        "azura",
+        "boethiah",
+        "nocturnal",
+        "zarthos",
+        "shadar",
+        "kobold",
+        "lich",
+        "oracle",
+        "summoner",
+        "geomancer",
+        "runeweaver",
+        "voidcaller",
+        "planewalker",
+    ]
+
+    adjective = random.choice(adjectives)
+    name = random.choice(names)
+    return f"{adjective}_{name}"

--- a/src/sourcerer/infrastructure/utils.py
+++ b/src/sourcerer/infrastructure/utils.py
@@ -4,9 +4,8 @@ Utility functions for the Sourcerer application.
 This module provides various utility functions used throughout the application,
 including UUID generation, MIME type detection, and file type checking.
 """
-
 import mimetypes
-import random
+import secrets
 import uuid
 from pathlib import Path
 
@@ -214,6 +213,6 @@ def generate_unique_name() -> str:
         "planewalker",
     ]
 
-    adjective = random.choice(adjectives)
-    name = random.choice(names)
+    adjective = secrets.choice(adjectives)
+    name = secrets.choice(names)
     return f"{adjective}_{name}"

--- a/src/sourcerer/presentation/screens/provider_creds_registration/main.py
+++ b/src/sourcerer/presentation/screens/provider_creds_registration/main.py
@@ -15,6 +15,7 @@ from sourcerer.domain.access_credentials.services import (
 from sourcerer.infrastructure.access_credentials.exceptions import (
     MissingAuthFieldsError,
 )
+from sourcerer.infrastructure.utils import generate_unique_name
 from sourcerer.presentation.di_container import DiContainer
 from sourcerer.presentation.screens.shared.widgets.button import Button
 from sourcerer.presentation.screens.shared.widgets.labeled_input import LabeledInput
@@ -215,7 +216,10 @@ class ProviderCredsRegistrationScreen(ModalScreen):
             if isinstance(input_field, LabeledInput) and input_field.get().value
         }
 
-        auth_name = self.query_one("#auth_name", LabeledInput).get().value or "default"
+        auth_name = (
+            self.query_one("#auth_name", LabeledInput).get().value
+            or generate_unique_name()
+        )
 
         return ProviderCredentialsEntry(
             name=auth_name,

--- a/src/sourcerer/utils.py
+++ b/src/sourcerer/utils.py
@@ -4,7 +4,7 @@ import uuid
 from pathlib import Path
 
 
-def get_encryption_key(path: Path):
+def get_encryption_key(path: Path) -> str:
     """
     Get the encryption key from a file or generate a new one if the file doesn't exist.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When registering provider credentials, a unique, fantasy-themed name is now automatically generated if no custom label is provided.
- **Style**
  - Minor update to function documentation by adding a return type annotation for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->